### PR TITLE
Add optional parameter to specify type of animation

### DIFF
--- a/lib/tree_view/tree_view.dart
+++ b/lib/tree_view/tree_view.dart
@@ -487,6 +487,7 @@ final class TreeView<Data, Tree extends ITreeNode<Data>>
     bool showRootNode = true,
     bool focusToNewNode = true,
     TreeReadyCallback<Data, Tree>? onTreeReady,
+    Animation<double>? animation,
   }) =>
       TreeView._(
         key: key,
@@ -505,6 +506,7 @@ final class TreeView<Data, Tree extends ITreeNode<Data>>
         showRootNode: showRootNode,
         onTreeReady: onTreeReady,
         focusToNewNode: focusToNewNode,
+        animation: animation,
       );
 
   /// The alternate implementation of [TreeView] uses an [IndexedNode] internally,

--- a/lib/tree_view/tree_view.dart
+++ b/lib/tree_view/tree_view.dart
@@ -64,12 +64,16 @@ final class TreeViewController<Data, Tree extends ITreeNode<Data>> {
   const TreeViewController(this._animatedListController);
 
   /// Method for programmatically scrolling to an [index] in the flat list of the [TreeView].
-  Future scrollToIndex(int index) async =>
-      _animatedListController.expansionBehaviourController.scrollToIndex(index);
+  Future scrollToIndex(int index,
+          [Duration duration = scrollAnimationDuration]) async =>
+      _animatedListController.expansionBehaviourController
+          .scrollToIndex(index, duration);
 
   /// Method for programmatically scrolling to a [node] in the [TreeView].
-  Future scrollToItem(Tree node) async =>
-      _animatedListController.expansionBehaviourController.scrollToItem(node);
+  Future scrollToItem(Tree node,
+          [Duration duration = scrollAnimationDuration]) async =>
+      _animatedListController.expansionBehaviourController
+          .scrollToItem(node, duration);
 
   /// Method for programmatically toggling the expansion state of a [TreeNode].
   /// If the [TreeNode] is in expanded state, then it will be collapsed.

--- a/lib/tree_view/tree_view.dart
+++ b/lib/tree_view/tree_view.dart
@@ -625,13 +625,13 @@ final class TreeView<Data, Tree extends ITreeNode<Data>>
           );
 
   @override
-  State<StatefulWidget> createState() => TreeViewState<Data, Tree>();
+  State<StatefulWidget> createState() => TreeViewState<Data, Tree>(animation);
 }
 
 class TreeViewState<Data, Tree extends ITreeNode<Data>>
     extends State<TreeView<Data, Tree>>
     with _TreeViewState<Data, Tree, TreeView<Data, Tree>> {
-  TreeViewState([Animation<double>? animation]) : _animation = animation;
+  TreeViewState(Animation<double>? animation) : _animation = animation;
 
   static const _errorMsg =
       "Animated list state not found from GlobalKey<AnimatedListState>";
@@ -700,6 +700,9 @@ class TreeViewState<Data, Tree extends ITreeNode<Data>>
 /// e.g. for path './.level1/level2', complexity is simply O(2).
 final class SliverTreeView<Data, Tree extends ITreeNode<Data>>
     extends _TreeView<Data, Tree> {
+  /// An optional animation for AnimatedList. If no animation is provided, AnimatedList falls back on its default.
+  final Animation<double>? animation;
+
   const SliverTreeView._({
     super.key,
     required super.builder,
@@ -713,6 +716,7 @@ final class SliverTreeView<Data, Tree extends ITreeNode<Data>>
     super.showRootNode,
     super.onTreeReady,
     super.focusToNewNode,
+    this.animation,
   }) : assert(
             expansionBehavior == ExpansionBehavior.none ||
                 scrollController != null,
@@ -721,7 +725,8 @@ final class SliverTreeView<Data, Tree extends ITreeNode<Data>>
             "For more info see example/lib/samples/sliver_treeview/sliver_treeview_sample.dart\n\n");
 
   @override
-  State<StatefulWidget> createState() => SliverTreeViewState<Data, Tree>();
+  State<StatefulWidget> createState() =>
+      SliverTreeViewState<Data, Tree>(animation);
 
   /// The default implementation of [SliverTreeView] that uses a [TreeNode] internally,
   /// which is based on the [Map] data structure for maintaining the children states.
@@ -760,6 +765,7 @@ final class SliverTreeView<Data, Tree extends ITreeNode<Data>>
     bool showRootNode = true,
     bool focusToNewNode = true,
     TreeReadyCallback<Data, TreeNode<Data>>? onTreeReady,
+    Animation<double>? animation,
   }) =>
       SliverTreeView._(
         key: key,
@@ -775,6 +781,7 @@ final class SliverTreeView<Data, Tree extends ITreeNode<Data>>
         showRootNode: showRootNode,
         onTreeReady: onTreeReady,
         focusToNewNode: focusToNewNode,
+        animation: animation,
       );
 
   /// Use the typed constructor if you are extending the [TreeNode] instead of
@@ -817,6 +824,7 @@ final class SliverTreeView<Data, Tree extends ITreeNode<Data>>
     bool showRootNode = true,
     bool focusToNewNode = true,
     TreeReadyCallback<Data, Tree>? onTreeReady,
+    Animation<double>? animation,
   }) =>
           SliverTreeView._(
             key: key,
@@ -832,6 +840,7 @@ final class SliverTreeView<Data, Tree extends ITreeNode<Data>>
             showRootNode: showRootNode,
             onTreeReady: onTreeReady,
             focusToNewNode: focusToNewNode,
+            animation: animation,
           );
 
   /// The alternate implementation of [SliverTreeView] uses an [IndexedNode]
@@ -869,6 +878,7 @@ final class SliverTreeView<Data, Tree extends ITreeNode<Data>>
     bool showRootNode = true,
     bool focusToNewNode = true,
     TreeReadyCallback<Data, IndexedTreeNode<Data>>? onTreeReady,
+    Animation<double>? animation,
   }) =>
       SliverTreeView._(
         key: key,
@@ -884,6 +894,7 @@ final class SliverTreeView<Data, Tree extends ITreeNode<Data>>
         showRootNode: showRootNode,
         onTreeReady: onTreeReady,
         focusToNewNode: focusToNewNode,
+        animation: animation,
       );
 
   /// Use the typed constructor if you are extending the [IndexedTreeNode] instead
@@ -929,6 +940,7 @@ final class SliverTreeView<Data, Tree extends ITreeNode<Data>>
     bool showRootNode = true,
     bool focusToNewNode = true,
     TreeReadyCallback<Data, Tree>? onTreeReady,
+    Animation<double>? animation,
   }) =>
           SliverTreeView._(
             key: key,
@@ -944,17 +956,21 @@ final class SliverTreeView<Data, Tree extends ITreeNode<Data>>
             showRootNode: showRootNode,
             onTreeReady: onTreeReady,
             focusToNewNode: focusToNewNode,
+            animation: animation,
           );
 }
 
 class SliverTreeViewState<Data, Tree extends ITreeNode<Data>>
     extends State<SliverTreeView<Data, Tree>>
     with _TreeViewState<Data, Tree, SliverTreeView<Data, Tree>> {
+  SliverTreeViewState(Animation<double>? animation) : _animation = animation;
   static const _errorMsg =
       "Sliver Animated list state not found from GlobalKey<SliverAnimatedListState>";
 
   late final GlobalKey<SliverAnimatedListState> _listKey =
       GlobalKey<SliverAnimatedListState>();
+
+  final Animation<double>? _animation;
 
   @override
   void insertItem(int index, {Duration duration = animationDuration}) {
@@ -968,7 +984,8 @@ class SliverTreeViewState<Data, Tree extends ITreeNode<Data>>
     if (_listKey.currentState == null) throw Exception(_errorMsg);
     _listKey.currentState!.removeItem(
       index,
-      (context, animation) => _removedItemBuilder(context, item, animation),
+      (context, animation) =>
+          _removedItemBuilder(context, item, _animation ?? animation),
       duration: duration,
     );
   }
@@ -979,7 +996,8 @@ class SliverTreeViewState<Data, Tree extends ITreeNode<Data>>
       key: _listKey,
       initialItemCount:
           _treeViewEventHandler.animatedListStateController.list.length,
-      itemBuilder: _insertedItemBuilder,
+      itemBuilder: (context, index, animation) =>
+          _insertedItemBuilder(context, index, _animation ?? animation),
     );
   }
 }

--- a/lib/tree_view/tree_view.dart
+++ b/lib/tree_view/tree_view.dart
@@ -430,6 +430,7 @@ final class TreeView<Data, Tree extends ITreeNode<Data>>
     bool showRootNode = true,
     bool focusToNewNode = true,
     TreeReadyCallback<Data, TreeNode<Data>>? onTreeReady,
+    Animation<double>? animation,
   }) =>
       TreeView._(
         key: key,
@@ -448,6 +449,7 @@ final class TreeView<Data, Tree extends ITreeNode<Data>>
         showRootNode: showRootNode,
         onTreeReady: onTreeReady,
         focusToNewNode: focusToNewNode,
+        animation: animation,
       );
 
   /// Use the typed constructor if you are extending the [TreeNode] instead of
@@ -542,6 +544,7 @@ final class TreeView<Data, Tree extends ITreeNode<Data>>
     bool showRootNode = true,
     bool focusToNewNode = true,
     TreeReadyCallback<Data, IndexedTreeNode<Data>>? onTreeReady,
+    Animation<double>? animation,
   }) =>
       TreeView._(
         key: key,
@@ -560,6 +563,7 @@ final class TreeView<Data, Tree extends ITreeNode<Data>>
         showRootNode: showRootNode,
         onTreeReady: onTreeReady,
         focusToNewNode: focusToNewNode,
+        animation: animation,
       );
 
   /// Use the typed constructor if you are extending the [IndexedTreeNode] instead
@@ -598,6 +602,7 @@ final class TreeView<Data, Tree extends ITreeNode<Data>>
     bool showRootNode = true,
     bool focusToNewNode = true,
     TreeReadyCallback<Data, Tree>? onTreeReady,
+    Animation<double>? animation,
   }) =>
           TreeView._(
             key: key,
@@ -616,6 +621,7 @@ final class TreeView<Data, Tree extends ITreeNode<Data>>
             showRootNode: showRootNode,
             onTreeReady: onTreeReady,
             focusToNewNode: focusToNewNode,
+            animation: animation,
           );
 
   @override

--- a/lib/tree_view/tree_view.dart
+++ b/lib/tree_view/tree_view.dart
@@ -373,6 +373,9 @@ final class TreeView<Data, Tree extends ITreeNode<Data>>
   /// For more information see the [AnimatedList.shrinkWrap]
   final bool shrinkWrap;
 
+  /// An optional animation for AnimatedList. If no animation is provided, AnimatedList falls back on its default.
+  final Animation<double>? animation;
+
   const TreeView._({
     super.key,
     super.expansionBehavior,
@@ -388,6 +391,7 @@ final class TreeView<Data, Tree extends ITreeNode<Data>>
     this.shrinkWrap = false,
     super.showRootNode,
     super.onTreeReady,
+    this.animation,
     super.focusToNewNode,
   });
 
@@ -619,11 +623,15 @@ final class TreeView<Data, Tree extends ITreeNode<Data>>
 class TreeViewState<Data, Tree extends ITreeNode<Data>>
     extends State<TreeView<Data, Tree>>
     with _TreeViewState<Data, Tree, TreeView<Data, Tree>> {
+  TreeViewState([Animation<double>? animation]) : _animation = animation;
+
   static const _errorMsg =
       "Animated list state not found from GlobalKey<AnimatedListState>";
 
   late final GlobalKey<AnimatedListState> _listKey =
       GlobalKey<AnimatedListState>();
+
+  final Animation<double>? _animation;
 
   @override
   void insertItem(int index, {Duration duration = animationDuration}) {
@@ -637,7 +645,8 @@ class TreeViewState<Data, Tree extends ITreeNode<Data>>
     if (_listKey.currentState == null) throw Exception(_errorMsg);
     _listKey.currentState!.removeItem(
       index,
-      (context, animation) => _removedItemBuilder(context, item, animation),
+      (context, animation) =>
+          _removedItemBuilder(context, item, _animation ?? animation),
       duration: duration,
     );
   }
@@ -653,7 +662,8 @@ class TreeViewState<Data, Tree extends ITreeNode<Data>>
       physics: widget.physics,
       padding: widget.padding,
       shrinkWrap: widget.shrinkWrap,
-      itemBuilder: _insertedItemBuilder,
+      itemBuilder: (context, index, animation) =>
+          _insertedItemBuilder(context, index, _animation ?? animation),
     );
   }
 }

--- a/lib/tree_view/tree_view_state_helper.dart
+++ b/lib/tree_view/tree_view_state_helper.dart
@@ -230,13 +230,14 @@ class TreeViewExpansionBehaviourController<Data> {
     required this.animatedListStateController,
   });
 
-  Future scrollToIndex(int index) async => await scrollController.scrollToIndex(
-        index,
-        preferPosition: AutoScrollPosition.begin,
-      );
+  Future scrollToIndex(int index,
+          [Duration duration = scrollAnimationDuration]) async =>
+      await scrollController.scrollToIndex(index,
+          preferPosition: AutoScrollPosition.begin, duration: duration);
 
-  Future scrollToItem(ITreeNode<Data> item) async =>
-      await scrollToIndex(animatedListStateController.indexOf(item));
+  Future scrollToItem(ITreeNode<Data> item,
+          [Duration duration = scrollAnimationDuration]) async =>
+      await scrollToIndex(animatedListStateController.indexOf(item), duration);
 
   Future<void> collapseNode(ITreeNode<Data> item) async {
     final removeItems = animatedListStateController.list.where((element) =>

--- a/test/node/node_test.dart
+++ b/test/node/node_test.dart
@@ -1,5 +1,4 @@
 import 'package:animated_tree_view/animated_tree_view.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../mocks/node_mocks.dart';


### PR DESCRIPTION
The default animations on `TreeView` and `SliverTreeView` work fine for small lists, but they break down with a large number of complex elements. This PR proposes an optional `Animation<double>? animation` parameter for each of them (as well as each of their respective constructors) that allows users to specify a custom animation, including suppressing animation altogether.

Omitting the `animation` parameter defaults animation to the package default, so this PR introduces no breaking changes.

I've also added an optional `duration` parameter to `scrollToItem` and `scrollToIndex` that defaults to the library default.

(Also—this is a feature born purely of self interest. I've got a big tree I'm trying to manage, and this library is perfect for my use case *except* that the thing freaks out when it tries to animate.)